### PR TITLE
Clang Tidy suggestions

### DIFF
--- a/include/CORA/CORA_problem.h
+++ b/include/CORA/CORA_problem.h
@@ -67,11 +67,11 @@ struct Manifolds {
 class Problem {
 private:
   /** dimension of the pose and landmark variables e.g., SO(dim_) */
-  const int64_t dim_;
+  const int dim_;
 
   /** rank of the relaxation e.g., the latent embedding space of Stiefel
    * manifold */
-  int64_t relaxation_rank_;
+  int relaxation_rank_;
 
   // maps from pose symbol to pose index (e.g., x1 -> 0, x2 -> 1, etc.)
   std::map<Symbol, int> pose_symbol_idxs_;
@@ -178,7 +178,7 @@ private:
   Index getTranslationIdx(const Symbol &trans_symbol) const;
 
 public:
-  Problem(int64_t dim, int64_t relaxation_rank,
+  Problem(int dim, int relaxation_rank,
           Formulation formulation = Formulation::Explicit,
           Preconditioner preconditioner = Preconditioner::BlockCholesky)
       : dim_(dim),
@@ -234,11 +234,15 @@ public:
   size_t getDataMatrixSize() const;
 
   Formulation getFormulation() const { return formulation_; }
-  size_t dim() const { return dim_; }
-  size_t numPoses() const { return pose_symbol_idxs_.size(); }
-  size_t numLandmarks() const { return landmark_symbol_idxs_.size(); }
-  size_t numRangeMeasurements() const { return range_measurements_.size(); }
-  size_t numTranslationalStates() const { return numPoses() + numLandmarks(); }
+  int dim() const { return dim_; }
+  int numPoses() const { return static_cast<int>(pose_symbol_idxs_.size()); }
+  int numLandmarks() const {
+    return static_cast<int>(landmark_symbol_idxs_.size());
+  }
+  int numRangeMeasurements() const {
+    return static_cast<int>(range_measurements_.size());
+  }
+  int numTranslationalStates() const { return numPoses() + numLandmarks(); }
 
   /*****  Riemannian optimization functions  *******/
 

--- a/include/CORA/CORA_problem.h
+++ b/include/CORA/CORA_problem.h
@@ -231,7 +231,7 @@ public:
   SparseMatrix getDataMatrix();
 
   // the full size of the full (explicit problem) data matrix
-  size_t getDataMatrixSize() const;
+  int getDataMatrixSize() const;
 
   Formulation getFormulation() const { return formulation_; }
   int dim() const { return dim_; }

--- a/include/CORA/CORA_types.h
+++ b/include/CORA/CORA_types.h
@@ -31,7 +31,7 @@ public:
                          std::to_string(act_cols) + ")") {}
 };
 inline void checkMatrixShape(const std::string &func_name, Index exp_rows,
-                             Index exp_cols, int act_rows, int act_cols) {
+                             Index exp_cols, Index act_rows, Index act_cols) {
   if (exp_rows != act_rows || exp_cols != act_cols) {
     throw MatrixShapeException(func_name, exp_rows, exp_cols, act_rows,
                                act_cols);

--- a/include/CORA/CORA_types.h
+++ b/include/CORA/CORA_types.h
@@ -18,18 +18,20 @@ public:
       : std::logic_error(str + " not implemented") {}
 };
 
+using Index = Eigen::Index;
+
 class MatrixShapeException : public std::logic_error {
 public:
-  MatrixShapeException(std::string func_name, int exp_rows, int exp_cols,
-                       int act_rows, int act_cols)
+  MatrixShapeException(const std::string &func_name, Index exp_rows,
+                       Index exp_cols, Index act_rows, Index act_cols)
       : std::logic_error(func_name + ": " + "expected matrix of shape (" +
                          std::to_string(exp_rows) + ", " +
                          std::to_string(exp_cols) + ") but got (" +
                          std::to_string(act_rows) + ", " +
                          std::to_string(act_cols) + ")") {}
 };
-inline void checkMatrixShape(std::string func_name, int exp_rows, int exp_cols,
-                             int act_rows, int act_cols) {
+inline void checkMatrixShape(const std::string &func_name, Index exp_rows,
+                             Index exp_cols, int act_rows, int act_cols) {
   if (exp_rows != act_rows || exp_cols != act_cols) {
     throw MatrixShapeException(func_name, exp_rows, exp_cols, act_rows,
                                act_cols);

--- a/include/CORA/MatrixManifold.h
+++ b/include/CORA/MatrixManifold.h
@@ -58,9 +58,7 @@ public:
     return (A.array() * B.array()).sum();
   }
 
-  Matrix retract(const Matrix &Y, const Matrix &V) const {
-    return projectToManifold(Y + V);
-  }
+  virtual Matrix retract(const Matrix &Y, const Matrix &V) const = 0;
 };
 
 } // namespace CORA

--- a/include/CORA/MatrixManifold.h
+++ b/include/CORA/MatrixManifold.h
@@ -58,7 +58,13 @@ public:
     return (A.array() * B.array()).sum();
   }
 
-  virtual Matrix retract(const Matrix &Y, const Matrix &V) const = 0;
+  Matrix retract(const Matrix &Y, const Matrix &V) const {
+    // We use projection-based retraction, as described in
+    // "Projection-Like Retractions on Matrix Manifolds" by Absil
+    // and Malick
+
+    return projectToManifold(Y + V);
+  }
 };
 
 } // namespace CORA

--- a/include/CORA/StiefelProduct.h
+++ b/include/CORA/StiefelProduct.h
@@ -20,13 +20,13 @@ namespace CORA {
 class StiefelProduct : public MatrixManifold {
 private:
   // Number of vectors in each orthonormal k-frame
-  size_t k_;
+  size_t k_{};
 
   // Dimension of ambient Euclidean space containing the frames
-  size_t p_;
+  size_t p_{};
 
   // Number of copies of St(k,p) in the product
-  size_t n_;
+  size_t n_{};
 
 public:
   /// CONSTRUCTORS AND MUTATORS
@@ -79,13 +79,6 @@ public:
   Matrix projectToTangentSpace(const Matrix &Y, const Matrix &V) const {
     return V - SymBlockDiagProduct(Y, Y, V);
   }
-
-  /** Given an element Y in M and a tangent vector V in T_Y(M), this function
-   * computes the retraction along V at Y using the QR-based retraction
-   * specified in eq. (4.8) of Absil et al.'s  "Optimization Algorithms on
-   * Matrix Manifolds").
-   */
-  Matrix retract(const Matrix &Y, const Matrix &V) const;
 
   /** Sample a random point on M, using the (optional) passed seed to initialize
    * the random number generator.  */

--- a/src/CORA_utils.cpp
+++ b/src/CORA_utils.cpp
@@ -103,11 +103,11 @@ CertResults fast_verification(const SparseMatrix &S, Scalar eta,
     // Calculate curvature along x
     theta = x.dot(S * x);
 
-    if (!(theta < -eta / 2)) {
+    if (theta >= -eta / 2) {
       /// STEP 3:  RUN PRECONDITIONED LOBPCG
 
       // We did *not* find a direction of sufficiently negative curvature in the
-      // alloted number of iterations, so now run preconditioned LOBPCG.  This
+      // allotted number of iterations, so now run preconditioned LOBPCG.  This
       // is most useful for the "hard" cases, in which M has a strictly negative
       // minimum eigenpair that is small-magnitude (i.e. near-zero).
 

--- a/src/ObliqueManifold.cpp
+++ b/src/ObliqueManifold.cpp
@@ -10,7 +10,7 @@ Matrix ObliqueManifold::projectToManifold(const Matrix &A) const {
 
   // in parallel, normalize each column of A to have unit norm
   Matrix A_normalized = A;
-  for (int64_t j = 0; j < A_normalized.cols(); j++) {
+  for (auto j = 0; j < A_normalized.cols(); j++) {
     A_normalized.col(j) /= A_normalized.col(j).norm();
   }
   return A_normalized;
@@ -37,8 +37,8 @@ Matrix ObliqueManifold::random_sample(
   // sample each column of the matrix from the standard normal distribution
   std::normal_distribution<Scalar> g;
   Matrix A(r_, n_);
-  for (int64_t j = 0; j < A.cols(); j++) {
-    for (int64_t i = 0; i < A.rows(); i++) {
+  for (auto j = 0; j < A.cols(); j++) {
+    for (auto i = 0; i < A.rows(); i++) {
       A(i, j) = g(generator);
     }
   }

--- a/src/StiefelProduct.cpp
+++ b/src/StiefelProduct.cpp
@@ -55,14 +55,6 @@ Matrix StiefelProduct::SymBlockDiagProduct(const Matrix &A, const Matrix &B,
   return R;
 }
 
-Matrix StiefelProduct::retract(const Matrix &Y, const Matrix &V) const {
-  // We use projection-based retraction, as described in
-  // "Projection-Like Retractions on Matrix Manifolds" by Absil
-  // and Malick
-
-  return projectToManifold(Y + V);
-}
-
 Matrix StiefelProduct::random_sample(
     const std::default_random_engine::result_type &seed) const {
   // Generate a matrix of the appropriate dimension by sampling its elements


### PR DESCRIPTION
- Use auto for type inference
- Rely on base class retract in `StiefelProduct.h`
- Replace int64_t with int, assuming problem sizes will be within range
- fixed typo