### PR TITLE
Clean up uses of d * n

### DIFF
--- a/include/CORA/CORA_problem.h
+++ b/include/CORA/CORA_problem.h
@@ -234,15 +234,29 @@ public:
   int getDataMatrixSize() const;
 
   Formulation getFormulation() const { return formulation_; }
-  int dim() const { return dim_; }
-  int numPoses() const { return static_cast<int>(pose_symbol_idxs_.size()); }
-  int numLandmarks() const {
+  inline int dim() const { return dim_; }
+  inline int numPoses() const {
+    return static_cast<int>(pose_symbol_idxs_.size());
+  }
+  inline int numPoseMeasurements() const {
+    return static_cast<int>(rel_pose_measurements_.size());
+  }
+  inline int numLandmarks() const {
     return static_cast<int>(landmark_symbol_idxs_.size());
   }
-  int numRangeMeasurements() const {
+  inline int numRangeMeasurements() const {
     return static_cast<int>(range_measurements_.size());
   }
-  int numTranslationalStates() const { return numPoses() + numLandmarks(); }
+  inline int numTranslationalStates() const {
+    return numPoses() + numLandmarks();
+  }
+
+  // Offset calculations
+  inline int rotationOffset() const { return 0; }
+  inline int rangeOffset() const { return dim() * numPoses(); }
+  inline int translationOffset() const {
+    return rangeOffset() + numRangeMeasurements();
+  }
 
   /*****  Riemannian optimization functions  *******/
 

--- a/include/CORA/CORA_problem.h
+++ b/include/CORA/CORA_problem.h
@@ -252,10 +252,9 @@ public:
   }
 
   // Offset calculations
-  inline int rotationOffset() const { return 0; }
-  inline int rangeOffset() const { return dim() * numPoses(); }
-  inline int translationOffset() const {
-    return rangeOffset() + numRangeMeasurements();
+  inline int numPosesDim() const { return dim() * numPoses(); }
+  inline int rotAndRangeMatrixSize() const {
+    return numPosesDim() + numRangeMeasurements();
   }
 
   /*****  Riemannian optimization functions  *******/

--- a/src/CORA.cpp
+++ b/src/CORA.cpp
@@ -263,10 +263,11 @@ Matrix projectSolution(const Problem &problem, const Matrix &Y) {
 
   // Project each spherical variable to the unit sphere by normalizing
   // the respective rows
-  int nd = n * d;
+  int rot_mat_sz = problem.numPosesDim();
 #pragma omp parallel for
   for (size_t i = 0; i < r; ++i) {
-    Yd.block(nd + i, 0, 1, d) /= Yd.block(nd + i, 0, 1, d).norm();
+    Yd.block(rot_mat_sz + i, 0, 1, d) /=
+        Yd.block(rot_mat_sz + i, 0, 1, d).norm();
   }
 
   if (problem.getFormulation() == Formulation::Explicit) {
@@ -278,7 +279,7 @@ Matrix projectSolution(const Problem &problem, const Matrix &Y) {
     Matrix X(d, (d + 1) * n);
 
     // Set rotational states
-    X.block(0, 0, d * n, d) = Yd;
+    X.block(0, 0, rot_mat_sz, d) = Yd;
 
     // Recover translational states
     throw NotImplementedException(


### PR DESCRIPTION
- Const function to calculate `numPosesDim`, which is `numPoses * dim_`. This quantity is often used as a matrix size or offset so avoiding scattered recalculation is probably a good idea.
- Same with rotAndRangeMatrixSize()
- Consolidate use of n * d, assign to `rot_mat_sz` when appropriate, although sometimes it is used for a `numPosesDim x 1` vector for translation
- Inlined some getter functions